### PR TITLE
Start the movies API server in port 3001 to allow people to run both

### DIFF
--- a/apis/movies/setup.sh
+++ b/apis/movies/setup.sh
@@ -14,4 +14,4 @@ touch database/database.sqlite;
 echo "Migrate & Seed";
 php artisan migrate;
 php artisan db:seed;
-php artisan serve --port=3000 --host localhost;
+php artisan serve --port=3001 --host localhost;


### PR DESCRIPTION
fixes #16

- Allow people to easily run both the stories & movies API servers at the same time
- Avoid having to explain about shutting down the stories server before you start the movies one. You currently need to do this - and the book doesn't mention this, you just get an error about ports being in use.