### PR TITLE
:hammer: remove type from script tag

### DIFF
--- a/homework/Chapter12/movies.html
+++ b/homework/Chapter12/movies.html
@@ -68,6 +68,6 @@
 </template>
 <script src="http://cdnjs.cloudflare.com/ajax/libs/vue/2.0.1/vue.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/vue-resource/0.7.0/vue-resource.js"></script>
-<script src='/js/app.js' type="text/javascript"></script>
+<script src='/js/app.js'></script>
 </body>
 </html>


### PR DESCRIPTION
As we are already using html5 there is no need to specify type="text/javascript" in the script tag for app.js